### PR TITLE
fix: use traveler state as default contact

### DIFF
--- a/src/core/types/travelerState.ts
+++ b/src/core/types/travelerState.ts
@@ -21,6 +21,7 @@ export interface TravelerState {
   id: string;
   travelerProfile: TravelerProfileType | null;
   name: string;
+  email: string;
   hasCurrentTrip: boolean;
   hasPastTrip: boolean;
   isActive: boolean;

--- a/src/features/payments/TripPurchasePage/trip-purchase-page.component.tsx
+++ b/src/features/payments/TripPurchasePage/trip-purchase-page.component.tsx
@@ -13,6 +13,7 @@ import { PixInformationSection } from "./pix-information.section";
 import { TripPaymentResult } from "@/services/api/payments/payTrip";
 import { TripPurchaseResponseSection } from "./trip-purchase-response.section";
 import { IsPaidSection } from "./is-paid.section";
+import { useAppStore } from "@/core/store";
 
 const MIN_PAYMENT = 100;
 const MAX_INSTALLMENTS = 6;
@@ -20,6 +21,7 @@ const MAX_INSTALLMENTS = 6;
 export function TripPurchasePage() {
   const { isLoading, tripPayer, error } = useTripPayer();
   const { priceData } = useTripPrice();
+  const { travelerState } = useAppStore();
   const [paymentMethod, setPaymentMethod] = useState<TripPaymentMethod>();
   const [writeGender, setWriteGender] = useState(false);
   
@@ -190,7 +192,7 @@ export function TripPurchasePage() {
           <DashedDivider className="trip-purchase__divider"/>
           <Box className="trip-purchase__section">
             <Text heading={true} size="xs">Contato</Text>
-            <Text className="trip-purchase__section__content" heading={false} size="md">{tripPayer?.email}</Text>
+            <Text className="trip-purchase__section__content" heading={false} size="md">{tripPayer?.email ?? travelerState.email}</Text>
             <input type="hidden" name="email" id="email" value={tripPayer?.email} />
             <input type="hidden" name="phone" id="phone" value={tripPayer?.phone} />
           </Box>


### PR DESCRIPTION
<!--
Items marcados com (*) são obrigatórios
-->

### Link da tarefa

<!--
[Título da tarefa]()
[Figma]()
-->

### Contexto do PR
![image](https://github.com/tripevolved/front-next/assets/9613666/523aefca-88bd-48dc-8fbc-b33cce09ec92)
Conforme conversamos ontem, no fluxo inicial de pagamento, onde o "Payer" ainda não foi criado (sempre ocorrerá na primeira compra do cliente), o contato ficava vazio. Nesse caso, usamos o default como sendo o email do travelerState do cliente.
<!--
Use esse espaço para explicar brevemente aos revisores o que eles precisam saber para conseguir revisar o seu PR
-->

#### Lista do que foi feito:

<!--
Exemplo:
- [ ] Adiciona o componente Button
- [ ] Atualiza a lib de cores
-->

#### Sobre a solução

<!--
Use esse espaço, caso necessário, para explicar o porquê de ter seguido com essa solução
-->

### Checklist

Esse PR:

- [x] foi testado localmente
- [ ] foi testado em ambiente de homologação
- [ ] possui testes unitários
- [ ] possui testes funcionais
- [ ] foi testado por alguém da equipe (não dev)

### Imagens, PrintScreens, vídeos

<!--
Use esse espaço para colocar tudo o que possa ajudar a visualizar o que você fez
-->

### Referências: artigos, documentação

<!--
Se você precisou usar referências para conseguir chegar à solução,
compartilhe com os revisores.
-->
