### PR TITLE
feat: whatsapp button trip button flow

### DIFF
--- a/src/features/destinations/DestinationPage/destination-page.component.tsx
+++ b/src/features/destinations/DestinationPage/destination-page.component.tsx
@@ -7,6 +7,9 @@ import { DestinationTipsSection } from "./destination-tips.section";
 import { DestinationPostsSection } from "./destinations-posts.section";
 import { DestinationFaqSection } from "./destination-faq.section";
 import { Button } from "mars-ds";
+import { UserCredentials } from "@/services/user/credentials";
+import { useRouter } from "next/router";
+import { getWhatsappLink } from "@/utils/helpers/whatsapp.helpers";
 
 const mock = {
   features: [
@@ -101,6 +104,18 @@ export function DestinationPage({ destination, seo, navbar, footer }: Destinatio
     videos = [],
     id,
   } = destination;
+  const router = useRouter();
+  const userData = UserCredentials.get();
+
+  const handleClick = (route: string) => {
+    if (userData?.idToken) {
+      router.push(route);
+    } else {
+      const wLink = getWhatsappLink(`Olá gostaria de ir para este destino: ${title}`);
+      router.push(wLink);
+    }
+  };
+
   return (
     <PageBase navbar={navbar} footer={footer} seo={seo}>
       <DestinationHeroSection title={title} photos={photos} />


### PR DESCRIPTION
<!--
Items marcados com (*) são obrigatórios
-->

### Link da tarefa

<!--
[Título da tarefa]()
[Figma]()
-->

### Contexto do PR
Hoje nosso botão "Quero ir" na página do App lança o usuário diretamente para a área logada. Isso exclui os usuários que talvez queiram obter a viagem de modo externo a plataforma, por isso seria necessário se alterar o fluxo para que estes usuários fosse redirecionados para o whatsapp.
<!--
Use esse espaço para explicar brevemente aos revisores o que eles precisam saber para conseguir revisar o seu PR
-->

#### Lista do que foi feito:

<!--
Exemplo:
- [ ] Adiciona o componente Button
- [ ] Atualiza a lib de cores
-->

#### Sobre a solução
No caso eu apliquei como regra verificar se o usuário possui um tokenId em suas credenciais e se sim, ele é lançado para a página de criação da viagem como é o fluxo normal. Caso não tenha este é redirecionado para o whatsapp.
<!--
Use esse espaço, caso necessário, para explicar o porquê de ter seguido com essa solução
-->

### Checklist

Esse PR:

- [ ] foi testado localmente
- [ ] foi testado em ambiente de homologação
- [ ] possui testes unitários
- [ ] possui testes funcionais
- [ ] foi testado por alguém da equipe (não dev)

### Imagens, PrintScreens, vídeos
![image](https://github.com/tripevolved/front-next/assets/39538844/a682175f-88cb-4c3c-a793-47121389f853)

<!--
Use esse espaço para colocar tudo o que possa ajudar a visualizar o que você fez
-->

### Referências: artigos, documentação

<!--
Se você precisou usar referências para conseguir chegar à solução,
compartilhe com os revisores.
-->
