### PR TITLE
fix: declare to typescript to always resolve "react" instead of resolution

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,8 @@
     "incremental": true,
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "react": ["node_modules/@types/react"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],


### PR DESCRIPTION

### Contexto do PR

Correção de configuração do typescript, esse bug surgiu após remover o cache do yarn.lock e remover o package-lock.json do projeto, nesse [PR](https://github.com/tripevolved/front-next/pull/346).

#### Lista do que foi feito:

- [x] Declarado o module @types/react no complier do tsconfing.json

#### Sobre a solução

Essa solução foi feita pois ao declarar diretamente pelo compiler options, o erro de tipagem sumiu. Essa solução é dada para que outras versões do react que estejam inclusas no projeto, possam conflitar.

### Checklist

Esse PR:

- [x] Rodar localmente a aplicação
- [x] Rodar localmente o build da aplicação

### Imagens, PrintScreens, vídeos

**Antes**
![Captura de Tela 2024-07-10 às 17 23 30](https://github.com/tripevolved/front-next/assets/5264498/e265822e-1483-4400-a31b-d1bb393e46b7)


**Depois**
![Captura de Tela 2024-07-10 às 17 22 22](https://github.com/tripevolved/front-next/assets/5264498/2689daa4-cedd-4f97-9b90-36bf52a9551e)
![Captura de Tela 2024-07-10 às 17 23 00](https://github.com/tripevolved/front-next/assets/5264498/410f5480-8662-4445-90d0-6e3c1962e15e)


### Referências: artigos, documentação

Essa solução foi baseada nessa [thread](https://github.com/facebook/react/issues/24304#issuecomment-1111184798) do github