### PR TITLE
fix: ajuste leiaute home

### DIFF
--- a/src/ui/components/sections/SectionFilterTravel/ListTravel/index.tsx
+++ b/src/ui/components/sections/SectionFilterTravel/ListTravel/index.tsx
@@ -50,7 +50,6 @@ export function ListTravel({ mainChoice, otherChoices }: ListTravelProps) {
           <div className="footer-item-travel primary">
             <span className="item-travel-list-title">{mainChoice.name}</span>
             <span className="item-travel-list-subtitle"></span>
-            <span className="item-travel-list-price">{mainChoice?.price}</span>
           </div>
         </div>
 
@@ -73,7 +72,6 @@ export function ListTravel({ mainChoice, otherChoices }: ListTravelProps) {
               </span>
               <div className="footer-item-travel second">
                 <span className="item-travel-list-title">{choice.name}</span>
-                <span className="item-travel-list-price">{choice?.price}</span>
               </div>
             </div>
           ))}

--- a/src/ui/components/sections/SectionFilterTravel/section-filter-travel.styles.scss
+++ b/src/ui/components/sections/SectionFilterTravel/section-filter-travel.styles.scss
@@ -236,7 +236,6 @@
   display: flex;
   flex-direction: column;
   align-items: self-start;
-  height: 85px;
   justify-content: space-between;
 }
 
@@ -281,6 +280,7 @@ button.btn-form-travel-primary {
   border-radius: 25px;
   border: none;
   color: white;
+  cursor: pointer;
 }
 
 button.btn-form-travel-second {
@@ -291,6 +291,15 @@ button.btn-form-travel-second {
   border-radius: 25px;
   border: 2px solid #0ab9ad;
   color: #0ab9ad;
+  cursor: pointer;
+}
+
+
+
+button.btn-form-travel-second:hover, button.btn-form-travel-primary:hover {
+  background-color: #00877a;
+  border-color:  #00877a;
+  color: white
 }
 
 span.item-travel-list-title {
@@ -308,7 +317,6 @@ span.item-travel-list-price {
 
 .footer-item-travel.second {
   justify-content: space-evenly;
-  height: 60px;
 }
 
 .footer-item-travel.second span.item-travel-list-title {


### PR DESCRIPTION
### Link da tarefa

[Ajustes menores vindos do alinhamento com design](https://github.com/orgs/tripevolved/projects/1/views/5?pane=issue&itemId=72282886&issue=tripevolved%7Cfront-next%7C363)


### Contexto do PR

Ajustes de leiaute na home.

#### Lista do que foi feito:

- [x] Remoção visualização do preço no destino
- [x] Atribuição de cursor:pointer nos botoes da home
- [x] Ajuste de comportamento de hover nos botões novos da home


### Checklist

Esse PR:

- [ ] foi testado localmente
- [ ] foi testado em ambiente de homologação
- [ ] possui testes unitários
- [ ] possui testes funcionais
- [ ] foi testado por alguém da equipe (não dev)

### Imagens, PrintScreens, vídeos

![edit-leiaute-home2](https://github.com/user-attachments/assets/f2dfcfc3-e568-4651-a05b-38bda1eb9893)



