### PR TITLE
fix: Removendo botão para visualizar itinerário completo

### DIFF
--- a/src/features/trips/NewItinerary/new-itinerary.component.tsx
+++ b/src/features/trips/NewItinerary/new-itinerary.component.tsx
@@ -96,20 +96,6 @@ export function NewItinerary({ tripId, title }: any) {
           cidade e vai até {title}, para que você só tenha o trabalho de curtir a sua viagem. Você
           pode alterar suas escolhas e estamos à disposição para atendê-lo da melhor forma.
         </Text>
-        <Button
-          variant="neutral"
-          href="#"
-          size="sm"
-          style={{
-            border: "none",
-            textDecoration: "underline",
-            padding: 0,
-            fontWeight: 500,
-            marginTop: 10,
-          }}
-        >
-          Ver itinerário completo
-        </Button>
       </div>
       <div className="itinerary">
         {groupedActions.map((group) => {


### PR DESCRIPTION
<!--
Items marcados com (*) são obrigatórios
-->

### Link da tarefa


[Task 383](https://github.com/tripevolved/front-next/issues/383)
[Link do Figma](https://www.figma.com/design/DM4cydQ2iPIIRDefXtbExl/Trip-Evolved?node-id=4029-3519&t=1xQT9TMoZBGPno2f-4)


### Contexto do PR

Nessa tarefa, foi requisitado que fosse removido o botão para mostrar o itinerário completo, pois o mesmo já estava sendo mostrado de forma completa na tela do usuário, tornando o botão desnecessário

#### Sobre a solução

Foi apenas removido o componente de botão da tela

### Checklist

Esse PR:

- [X] foi testado localmente
- [ ] foi testado em ambiente de homologação
- [ ] possui testes unitários
- [ ] possui testes funcionais
- [ ] foi testado por alguém da equipe (não dev)

### Imagens, PrintScreens, vídeos


Antes: 
![image](https://github.com/user-attachments/assets/1f0dc53b-3147-47f9-a483-2cea449b29fd)


Depois: 

![image](https://github.com/user-attachments/assets/deb21205-7c96-4d57-ac32-76701fa55abd)


