### PR TITLE
fix: ajustando responsivo na tela de detalhes da viagem

### DIFF
--- a/src/features/trips/TripDetailsPage/trip-details-page.styles.scss
+++ b/src/features/trips/TripDetailsPage/trip-details-page.styles.scss
@@ -56,6 +56,6 @@
 
 .trip-stay-center-margin {
   margin: 0 auto;
-  width: 88%;
+  width: 92%;
   padding-top: 16px;
 }


### PR DESCRIPTION


### Link da tarefa

[Task 389](https://github.com/tripevolved/front-next/issues/389)

### Contexto do PR

Era necessário que fosse ajustado a responsividade da tela de detalhes ao tentar omprar uma viagem

#### Lista do que foi feito:

- [ ] Ajustado largura da tela de detalhes no responsivo


#### Sobre a solução

Apenas foi ajustada a largura para a tela responsiva, para assim o conteúdo se encaixar melhor no eixo vertical a tela

### Checklist

Esse PR:

- [X] foi testado localmente
- [ ] foi testado em ambiente de homologação
- [ ] possui testes unitários
- [ ] possui testes funcionais
- [ ] foi testado por alguém da equipe (não dev)

### Imagens, PrintScreens, vídeos

![GIF - Responsivo](https://github.com/user-attachments/assets/8fdfb5f8-9ea9-4dd2-b3c8-53492f905bd0)


