### PR TITLE
Adicionando loading ao buscar um itinerário

### DIFF
--- a/src/features/trips/NewItinerary/new-itinerary.component.tsx
+++ b/src/features/trips/NewItinerary/new-itinerary.component.tsx
@@ -9,6 +9,7 @@ import { FlightAction } from "../Itinerary/flight.action";
 import { RouteAction } from "../Itinerary/route.action";
 import { ItineraryEnd } from "../Itinerary/itinerary-end.action";
 import { DestinationDetails } from "./destination-details/destination-details.component";
+import { TripDetailsPageLoading } from "../TripDetailsPage/trip-details-page.loading";
 
 export function NewItinerary({ tripId, title }: any) {
   const [data, setData] = useState<ItineraryListV2>();
@@ -83,7 +84,8 @@ export function NewItinerary({ tripId, title }: any) {
   }, [itinerary]);
 
   if (error) return <ErrorState />;
-  if (!data) return <EmptyState />;
+  if (!data?.isReady) return <TripDetailsPageLoading />;
+  if (data.isReady && !data) return <EmptyState />;
 
   return (
     <div className="new-itinerary">


### PR DESCRIPTION


### Link da tarefa

[Tarefa 382](https://github.com/tripevolved/front-next/issues/382)

### Contexto do PR

Basicamente, o que estava acontecendo era que ao tentar acessar um itinerário pela primeira vez, não estava sendo exibido alguma espécie de loading ou algo do tipo, ao invés disso, estava sendo exibido uma imagem de "Nao encontrado", gerando assim uma quebra de UX pro usuário, que não possuía visão de que seu conteúdo estava sendo carregado e de que ele deveria aguardar

#### Lista do que foi feito:

- [ ] Adicionada lógica para exibir loading enquanto a propriedade `isReady` não estiver marcada como `true`
- [ ] Adicionada lógica para exibir o componente de "Não encontrado", apenas quando carregar o conteúdo e não tiver nenhuma informação retornada

#### Sobre a solução

Foi uma solução bem simples, justamente pela propriedade isReady foi fácil de realizar o controle do loading para o itinerário

### Checklist

Esse PR:

- [X] foi testado localmente
- [ ] foi testado em ambiente de homologação
- [ ] possui testes unitários
- [ ] possui testes funcionais
- [ ] foi testado por alguém da equipe (não dev)

### Imagens, PrintScreens, vídeos

![image](https://github.com/user-attachments/assets/30e6e8b4-587b-44b7-a2c2-d8ea052b31f8)

### Referências: artigos, documentação

<!--
Se você precisou usar referências para conseguir chegar à solução,
compartilhe com os revisores.
-->
