### PR TITLE
Ajustando modal de detalhes do voo

### DIFF
--- a/src/features/trips/FlightDetailsPanel/flight-details-panel.component.tsx
+++ b/src/features/trips/FlightDetailsPanel/flight-details-panel.component.tsx
@@ -1,30 +1,18 @@
 import type { FlightDetailsPanelProps } from "./flight-details-panel.types";
-import useSwr from "swr";
 
 import { Text, Box, ErrorState } from "@/ui";
 import { FlightCard } from "@/features";
 
 import { makeCn } from "@/utils/helpers/css.helpers";
-import { TransportationApiService } from "@/services/api";
-import { TripTransportation } from "@/core/types";
 import { Grid, Skeleton } from "mars-ds";
 
 export function FlightDetailsPanel({
   className,
   children,
   sx,
-  actionId,
-  tripId,
+  data,
   ...props
 }: FlightDetailsPanelProps) {
-  console.log(props);
-  const fetcher = async () =>
-    TransportationApiService.getTransportationActionItinerary(tripId, actionId);
-  const { data, error } = useSwr<TripTransportation>("get-flight-details", fetcher, {
-    revalidateOnMount: false,
-    refreshInterval: 120000,
-  });
-
   const LoadingSkeleton = () => (
     <Grid className="py-md flex flex-col gap-3" columns={{ sm: 2, md: 1 }}>
       <Skeleton height={50} active />

--- a/src/features/trips/FlightDetailsPanel/flight-details-panel.test.tsx
+++ b/src/features/trips/FlightDetailsPanel/flight-details-panel.test.tsx
@@ -44,11 +44,20 @@ const mock: TripTransportation = {
   },
   isBuilding: false,
   isSelected: true,
+  isReady: true,
+  transportationType: "FLIGHT",
+  from: "POA - Salgado Filho",
+  previousActionId: "29cee8c1-2ea9-481c-b8b0-adc859a85e4b",
+  nextActionId: "8a66d83e-8b93-4526-b2b9-5ec5bdbc947c",
+  actionId: "bd4257b0-5780-4346-b92f-a42f47477177",
+  fromLatitude: -29.994722,
+  fromLongitude: -51.171111,
+  isMain: true,
   message: "",
 };
 
 const makeSut = (props?: FlightDetailsPanelProps) =>
-  render(<FlightDetailsPanel {...props} flightView={mock.flightView} />);
+  render(<FlightDetailsPanel {...props} data={mock} />);
 
 describe("<FlightDetailsPanel>", () => {
   it("should render component", () => {

--- a/src/features/trips/FlightDetailsPanel/flight-details-panel.types.ts
+++ b/src/features/trips/FlightDetailsPanel/flight-details-panel.types.ts
@@ -1,6 +1,5 @@
 import type { CompanyFlightView, ComponentHTMLProps, TripTransportation } from "@/core/types";
 
 export interface FlightDetailsPanelProps extends ComponentHTMLProps {
-  actionId: string;
-  tripId: string;
+  data?: TripTransportation;
 }

--- a/src/features/trips/Itinerary/flight.action.tsx
+++ b/src/features/trips/Itinerary/flight.action.tsx
@@ -3,6 +3,7 @@ import { Text, CardHighlight, Picture } from "@/ui";
 import { FlightDetailsPanel } from "@/features";
 import { TripTransportation } from "@/core/types";
 import { TransportationApiService } from "@/services/api";
+import useSwr from "swr";
 
 export const FlightAction = ({
   action,
@@ -11,8 +12,21 @@ export const FlightAction = ({
   action: TripTransportation;
   tripId: string;
 }) => {
+  const fetcher = async () =>
+    TransportationApiService.getTransportationActionItinerary(tripId, action.actionId);
+
+  const { data: searchedFlightDetails } = useSwr<TripTransportation>(
+    "get-flight-details",
+    fetcher,
+    {
+      revalidateOnMount: false,
+      refreshInterval: 180000,
+      fallbackData: action,
+    }
+  );
+
   const handleSeeDetails = async () => {
-    Modal.open(() => <FlightDetailsPanel tripId={tripId} actionId={action.actionId} />, {
+    Modal.open(() => <FlightDetailsPanel data={searchedFlightDetails} />, {
       size: "md",
       closable: true,
     });


### PR DESCRIPTION


### Link da tarefa

[Tarefa 387](https://github.com/tripevolved/front-next/issues/387)

### Contexto do PR

Basicamente estava sendo requisitado que fosse melhorado a disponibilização da modal de detalhes do voo, onde, foi requisitado que fosse inserido um loading, e consequentemente com isso, também ajustado o código para salvar os dados e evitar chamadas desnecessárias ao abrir a modal

#### Lista do que foi feito:

- [ ] Adicionado Skeleton ao abrir a modal
- [ ] Adicionado lógica para evitar chamadas ao abrir a modal

#### Sobre a solução

Acabei me utilizando do próprio SWR, para manter uma utilização do cache e evitar que fossem feitas várias chamadas desnecessárias ao abrir a modal, também optei por utilizar o Skeleton para exibir o loading por puro efeito estético, acabei considerando uma opção melhor do que um loading convencional

### Checklist

Esse PR:

- [ ] foi testado localmente
- [ ] foi testado em ambiente de homologação
- [ ] possui testes unitários
- [ ] possui testes funcionais
- [ ] foi testado por alguém da equipe (não dev)

### Imagens, PrintScreens, vídeos

![image](https://github.com/user-attachments/assets/6f38c053-7239-4ee2-9bae-98c4f47af216)

![image](https://github.com/user-attachments/assets/90290468-7bae-48fd-bfda-3845f017d54b)


### Referências: artigos, documentação

<!--
Se você precisou usar referências para conseguir chegar à solução,
compartilhe com os revisores.
-->
