### PR TITLE
Adicionando ícones no FAQ do destino

### DIFF
--- a/src/features/destinations/DestinationPage/destination-page.component.tsx
+++ b/src/features/destinations/DestinationPage/destination-page.component.tsx
@@ -30,31 +30,31 @@ const mock = {
   faq: [
     {
       question: "Transporte",
-      type: "/assets/destino/passagem-aerea.svg",
+      icon: "/assets/destino/passagem-aerea_green.svg",
       answer:
         "Escolheremos a melhor forma de transporte para você: passagem aérea, de ônibus ou aluguel de carro conforme a sua necessidade e escolha e conforme a disponibilidade no site. Somente a emissão das passagens aéreas ou de ônibus ou a reserva do automóvel garantem os valores.",
     },
     {
       question: "Hospedagem",
-      type: "/assets/destino/hospedagem.svg",
+      icon: "/assets/destino/hospedagem_green.svg",
       answer:
         'As hospedagens que disponibilizamos são escolhidas a dedo por nossos especialistas de viagem e terão o "selo Trip Evolved" destacado no momento da escolha, conforme a disponibilidade para sua viagem. Entretanto, você pode escolher outra hospedagem, se assim desejar. Importante verificar tipo de tarifa da hospedagem se é reembolsável ou não reembolsável. Em caso de desistência da compra da viagem, será cobrada multa referente aos fornecedores, caso haja.',
     },
     {
       question: "Roteiro completo",
-      type: "/assets/destino/roteiro.svg",
+      icon: "/assets/destino/roteiro_green.svg",
       answer:
         "Construiremos seu roteiro completo, entendendo suas necessidades e preferências e se você gosta de uma viagem mais cheia, com tudo o que tem direito, ou mais tranquila, para descansar e relaxar. Isso começa na escolha do destino e continua com a construção do roteiro com todos os passeios, atrações, restaurantes, bares e festas que se encaixarem no seu perfil de viajante e vontade na viagem.",
     },
     {
       question: "Dicas gastronômicas",
-      type: "/assets/destino/dicas-gastronomicas.svg",
+      icon: "/assets/destino/dicas-gastronomicas_green.svg",
       answer:
         "A indicação de restaurantes e bares é realizada conforme o seu perfil e suas escolhas. Levamos em consideração se você prefere massas, carnes, sushi ou aquele restaurante vegano maravilhoso. Além, é claro, da qualidade da gastronomia e do atendimento em cada um dos restaurantes que indicamos na plataforma.",
     },
     {
       question: "Suporte durante a viagem",
-      type: "/assets/destino/suporte.svg",
+      icon: "/assets/destino/suporte_green.svg",
       answer:
         "Você possui suporte durante toda a viagem, em 360º, desde a compra até retornar à sua cidade. Precisando, é só entrar em contato com nosso suporte via WhatsApp.",
     },
@@ -91,8 +91,8 @@ const mock = {
       source: "kSvaiM9Go2Y",
     },
   ],
-  travelerProfiles: [ "relax", "aventureiro" ],
-  travelType: "COUPLES"
+  travelerProfiles: ["relax", "aventureiro"],
+  travelType: "COUPLES",
 };
 
 export function DestinationPage({ destination, seo, navbar, footer }: DestinationPageProps) {
@@ -106,21 +106,23 @@ export function DestinationPage({ destination, seo, navbar, footer }: Destinatio
     uniqueName,
     videos = [],
     travelerProfiles = [],
-    travelType
+    travelType,
   } = destination;
   const Cta = () => <DestinationCta uniqueName={uniqueName} destinationTitle={destination.title} />;
 
   return (
     <PageBase navbar={navbar} footer={footer} seo={seo}>
       <DestinationHeroSection title={title} photos={photos} />
-      <DestinationProfileSection title={title} travelerProfiles={travelerProfiles} travelType={travelType} />
+      <DestinationProfileSection
+        title={title}
+        travelerProfiles={travelerProfiles}
+        travelType={travelType}
+      />
       <DestinationInfoSection features={features} recommendedBy={recommendedBy}>
         <Cta />
       </DestinationInfoSection>
       {videos.length ? <DestinationVideoSection title={title} videos={videos} /> : null}
-      {tips.length ? (
-        <DestinationTipsSection tips={tips} />
-      ) : null}
+      {tips.length ? <DestinationTipsSection tips={tips} /> : null}
       {posts.length ? <DestinationPostsSection posts={posts} /> : null}
       <DestinationFaqSection faq={mock.faq} title={title}>
         <Cta />


### PR DESCRIPTION

### Link da tarefa

[Tarefa 404](https://github.com/tripevolved/front-next/issues/404)

### Contexto do PR

Foi notado que na FAQ do destino, não estava sendo seguido o layout corretamente, exibindo a versão sem ícones:
![image](https://github.com/user-attachments/assets/59a017d7-f6d0-4eb8-87b1-4978f05eec33)

ao invés da versão que estava no figma: 

![image](https://github.com/user-attachments/assets/99d23501-a16a-41c5-9704-a9670172af23)



#### Lista do que foi feito:

- [ ] Foi ajustada a nomenclatura dos ícones e o nome da propriedade

Esse PR:

- [X] foi testado localmente
- [ ] foi testado em ambiente de homologação
- [ ] possui testes unitários
- [ ] possui testes funcionais
- [ ] foi testado por alguém da equipe (não dev)

### Imagens, PrintScreens, vídeos

![image](https://github.com/user-attachments/assets/f0bc22c1-d858-454f-90b1-a324dc7394e6)
