### PR TITLE
feat: mostrar "não encontrado" quando não haver hospedagem para apresentar

### DIFF
--- a/src/features/trips/Itinerary/stay.action.tsx
+++ b/src/features/trips/Itinerary/stay.action.tsx
@@ -104,7 +104,7 @@ export const StayAction = ({ action, tripId }: Props) => {
                 )}
               </div>
             </div>
-            <Button
+            {(action.isSelected) ? <Button
               variant="neutral"
               size="sm"
               style={{
@@ -118,7 +118,7 @@ export const StayAction = ({ action, tripId }: Props) => {
               onClick={handleSeeDetails}
             >
               Ver Detalhes
-            </Button>
+            </Button> : <Text as="p" size="xs" style={{ marginTop: 0 }}>Não encontrado</Text>}
             {action.highlight && <TripStayHighlightSection highlight={action.highlight} />}
           </div>
         </div>


### PR DESCRIPTION
### Contexto do PR

Quando não houver hospedagem para mostrar, apresentar "não encontrado" no lugar de "ver detalhes"


### Checklist

Esse PR:

- [ ] foi testado localmente
- [ ] foi testado em ambiente de homologação
- [ ] possui testes unitários
- [ ] possui testes funcionais
- [ ] foi testado por alguém da equipe (não dev)

### Imagens, PrintScreens, vídeos

![image](https://github.com/user-attachments/assets/9711a765-6413-4b83-a3df-d981532f88a0)


