### PR TITLE
fix: adding text to show trip min and max price

### DIFF
--- a/src/features/trips/TripSteps/step-configuration.tsx
+++ b/src/features/trips/TripSteps/step-configuration.tsx
@@ -43,9 +43,6 @@ export function StepConfiguration({ onNext, endDate, startDate }: StepConfigurat
           setDays(daysAmount);
         }}
       />
-      <Text heading size="xs" className="mt-md">
-        Até quanto pode gastar ao total?
-      </Text>
       <div
         style={{
           display: "flex",
@@ -62,7 +59,7 @@ export function StepConfiguration({ onNext, endDate, startDate }: StepConfigurat
             fontWeight: 600,
           }}
         >
-          Valor da trip de R$500 a R$10.000
+          Vamos encontrar a melhor opção para o seu orçamento de viagem
         </Text>
       </div>
       <SubmitButton


### PR DESCRIPTION


### Link da tarefa

[](url)
### Contexto do PR

Apenas foi definido que ao invés de exibir um slider, fosse exibido um texto para mostrar o valor mínimo e máximo da trip, com o objetivo de facilitar para o usuário, saber qual o preço máximo que pode pagar em sua viagem

#### Lista do que foi feito:

- [ ] Remoção do Slider
- [ ] Adição do texto
- [ ] Estilização do texto
- [ ] Remoção de código inutilizado

#### Sobre a solução

Apenas foi removido o slider e adicionado um texto por cima, além da remoção de tipagens que não estavam sendo mais usadas no código

### Checklist

Esse PR:

- [ ] foi testado localmente
- [ ] foi testado em ambiente de homologação
- [ ] possui testes unitários
- [ ] possui testes funcionais
- [ ] foi testado por alguém da equipe (não dev)

### Imagens, PrintScreens, vídeos

![image](https://github.com/user-attachments/assets/d3c32e55-098e-49a1-916a-ced047f5fc79)

