### PR TITLE
feat: added previous button in steps

### DIFF
--- a/src/features/questions/QuestionNavigationController/question-navigation-controller.component.tsx
+++ b/src/features/questions/QuestionNavigationController/question-navigation-controller.component.tsx
@@ -13,20 +13,21 @@ export const QuestionNavigationController = ({
   style,
   nextButtonLabel = "Próxima",
   finishButtonLabel = "Concluir",
+  showPreviousButton,
 }: ProfileQuestionsNavigationProps) => {
   const label = useMemo(
     () => (position === total ? finishButtonLabel : nextButtonLabel),
     [finishButtonLabel, nextButtonLabel, position, total]
   );
   const cn = makeCn("profile-questions-navigation", className)();
-  const showPreviousButton = total > 1;
+  const previousButton = showPreviousButton || total > 1;
   return (
     <div className={cn} style={style}>
-      {showPreviousButton ? (
+      {previousButton ? (
         <Button
           variant="neutral"
           className="profile-questions-navigation__previous"
-          disabled={position < 1}
+          disabled={showPreviousButton ? false : position < 1}
           iconName="chevron-left"
           onClick={() => onNavigation(position - 1)}
         >

--- a/src/features/questions/QuestionNavigationController/question-navigation-controller.types.ts
+++ b/src/features/questions/QuestionNavigationController/question-navigation-controller.types.ts
@@ -8,4 +8,5 @@ export interface ProfileQuestionsNavigationProps {
   submitting?: boolean;
   nextButtonLabel?: string;
   finishButtonLabel?: string;
+  showPreviousButton?: boolean;
 }

--- a/src/features/questions/QuestionsBuilder/questions-builder.component.tsx
+++ b/src/features/questions/QuestionsBuilder/questions-builder.component.tsx
@@ -18,6 +18,8 @@ const swrOptions = { revalidateOnFocus: false };
 
 export function QuestionsBuilder({
   onSubmit,
+  onPrevious,
+  showPreviousButton,
   hideStepper,
   nextButtonLabel,
   finishButtonLabel,
@@ -47,12 +49,14 @@ export function QuestionsBuilder({
     .find((answer) => answer.title === "Nenhum dos listados")?.id;
 
   const handleSteps = (newIndex: number) => {
+    console.log("newIndex", newIndex);
     let submittedAnswers = answers;
     if (!Object.values(answers).flat().length) {
       submittedAnswers = {
         [data[currentIndex].questions[0].id]: noneOfTheListedQuestionId as string,
       };
     }
+    if (newIndex < 0 && onPrevious) return onPrevious();
     if (newIndex < 0) return;
     if (total >= newIndex) setCurrentIndexAnimation(newIndex);
     else onSubmit(submittedAnswers);
@@ -138,6 +142,7 @@ export function QuestionsBuilder({
         submitting={submitting}
         nextButtonLabel={nextButtonLabel}
         finishButtonLabel={buttonLabel}
+        showPreviousButton={showPreviousButton}
       />
     </Grid>
   );

--- a/src/features/questions/QuestionsBuilder/questions-builder.types.ts
+++ b/src/features/questions/QuestionsBuilder/questions-builder.types.ts
@@ -8,6 +8,7 @@ export type QuestionsBuilderOnSubmit = (answers: AnswersDto) => void;
 export interface QuestionsBuilderProps {
   title?: string;
   onSubmit: QuestionsBuilderOnSubmit;
+  onPrevious?: () => void;
   controllerKey: string;
   controller: Controller;
   disableLocalSave?: boolean;
@@ -15,4 +16,5 @@ export interface QuestionsBuilderProps {
   hideStepper?: boolean;
   nextButtonLabel?: string;
   finishButtonLabel?: string;
+  showPreviousButton?: boolean;
 }

--- a/src/features/trips/TripCreationPage/trip-creation-page.component.tsx
+++ b/src/features/trips/TripCreationPage/trip-creation-page.component.tsx
@@ -35,7 +35,7 @@ const LOADING_STEPS = [
 const DEFAULT_INITIAL_INDEX = 0;
 
 const StepBuilder = ({ steps }: TemplateStepsBuilderProps) => {
-  const { id: travelerId } = useAppStore((state) => state.travelerState);
+  const { id: travelerId, hasValidAddress } = useAppStore((state) => state.travelerState);
 
   const [currentIndex, setCurrentIndex] = useState(DEFAULT_INITIAL_INDEX);
   const [submitting, setSubmitting] = useState(false);
@@ -75,6 +75,11 @@ const StepBuilder = ({ steps }: TemplateStepsBuilderProps) => {
     router.replace(`/app/viagens/${tripId.current}/detalhes`);
   };
 
+  const handlePrevious = () => {
+    const steps = currentIndex === 2 && hasValidAddress ? 2 : 1;
+    return setCurrentIndex((state) => state - steps);
+  };
+
   const { component: Component } = steps[currentIndex];
 
   if (submitting) {
@@ -94,7 +99,7 @@ const StepBuilder = ({ steps }: TemplateStepsBuilderProps) => {
       <div style={slider.style}>
         <Component
           onNext={handleNext}
-          onPrevious={() => setCurrentIndex((state) => state - 1)}
+          onPrevious={handlePrevious}
           goToStepName={() => {}}
           {...data.current}
         />

--- a/src/features/trips/TripCreationPage/trip-creation-page.steps.tsx
+++ b/src/features/trips/TripCreationPage/trip-creation-page.steps.tsx
@@ -26,6 +26,7 @@ export const GROUP_STEPS: TemplateStepsBuilderProps["steps"] = [
         {...props}
         startDate={String(addMonths(new Date(), 3))}
         endDate={String(addMonths(new Date(), 3))}
+        showPrevious={true}
       />
     ),
   },

--- a/src/features/trips/TripSteps/step-city-registration.tsx
+++ b/src/features/trips/TripSteps/step-city-registration.tsx
@@ -3,10 +3,12 @@ import type { StepComponentProps } from "@/features";
 import { RegisterApiService } from "@/services/api";
 import { StepCity } from "./step-city";
 
-export function StepCityRegistration({ onNext }: StepComponentProps) {
+export function StepCityRegistration({ onNext, onPrevious }: StepComponentProps) {
   const { id: travelerId, hasValidAddress } = useAppStore((state) => state.travelerState);
 
-  if (hasValidAddress) { onNext(); }
+  if (hasValidAddress) {
+    onNext();
+  }
 
   const onSubmit = async (cityId: string) => {
     await RegisterApiService.putRegisterCity({

--- a/src/features/trips/TripSteps/step-configuration.tsx
+++ b/src/features/trips/TripSteps/step-configuration.tsx
@@ -1,16 +1,23 @@
 import type { StepComponentProps } from "@/features";
 import { DatePicker, Text } from "@/ui";
 import { formatToCurrencyBR } from "@/utils/helpers/number.helpers";
-import { Grid, Slider, SubmitButton, TextField } from "mars-ds";
+import { Button, Grid, Slider, SubmitButton, TextField } from "mars-ds";
 import { useState } from "react";
 import { differenceInDays } from "date-fns";
 
 interface StepConfigurationProps extends StepComponentProps {
   endDate?: string;
   startDate?: string;
+  showPrevious?: boolean;
 }
 
-export function StepConfiguration({ onNext, endDate, startDate }: StepConfigurationProps) {
+export function StepConfiguration({
+  onNext,
+  onPrevious,
+  endDate,
+  startDate,
+  showPrevious,
+}: StepConfigurationProps) {
   const defaultDates = [
     startDate ? new Date(startDate) : undefined,
     endDate ? new Date(endDate) : undefined,
@@ -62,14 +69,28 @@ export function StepConfiguration({ onNext, endDate, startDate }: StepConfigurat
           Vamos encontrar a melhor opção para o seu orçamento de viagem
         </Text>
       </div>
-      <SubmitButton
-        className="mt-md"
-        variant="tertiary"
-        disabled={isDisabled}
-        onClick={handleSubmit}
-      >
-        Continuar
-      </SubmitButton>
+
+      <div className="mt-md profile-questions-navigation">
+        {showPrevious && (
+          <Button
+            onClick={onPrevious}
+            iconName="chevron-left"
+            variant="neutral"
+            className="profile-questions-navigation__previous"
+          >
+            Anterior
+          </Button>
+        )}
+
+        <SubmitButton
+          variant="tertiary"
+          disabled={isDisabled}
+          onClick={handleSubmit}
+          className="profile-questions-navigation__next"
+        >
+          Continuar
+        </SubmitButton>
+      </div>
     </Grid>
   );
 }

--- a/src/features/trips/TripSteps/step-room-choice.tsx
+++ b/src/features/trips/TripSteps/step-room-choice.tsx
@@ -2,19 +2,30 @@ import { useState } from "react";
 
 import type { StepComponentProps } from "@/features";
 import { IncrementField, Text } from "@/ui";
-import { Grid, SubmitButton } from "mars-ds";
+import { Button, Grid, SubmitButton } from "mars-ds";
 
 import { formatToPlural } from "@/utils/helpers/number.helpers";
 
-export function StepRoomChoice({ onNext, travelersIntermediate, rooms }: StepComponentProps) {
+export function StepRoomChoice({
+  onNext,
+  onPrevious,
+  travelersIntermediate,
+  rooms,
+}: StepComponentProps) {
   const [submitting, setSubmitting] = useState(false);
-  const [roomsInfo, setRoomsInfo] = useState(([ { adults: travelersIntermediate.adults, children: travelersIntermediate.children, childrenAges: [] } ]));
+  const [roomsInfo, setRoomsInfo] = useState([
+    {
+      adults: travelersIntermediate.adults,
+      children: travelersIntermediate.children,
+      childrenAges: [],
+    },
+  ]);
   const childrenAgeInfo = travelersIntermediate.childrenAges as number[];
 
   const handleSubmit = () => {
     setSubmitting(true);
     let childrenCount = 0;
-    const roomsToSend = roomsInfo.map((r, i) => { 
+    const roomsToSend = roomsInfo.map((r, i) => {
       let roomChildrenAges = [] as number[];
       if (r.children > 0) {
         roomChildrenAges = childrenAgeInfo.slice(childrenCount, r.children);
@@ -22,7 +33,12 @@ export function StepRoomChoice({ onNext, travelersIntermediate, rooms }: StepCom
       }
       return { adults: r.adults, children: r.children, childrenAges: roomChildrenAges };
     });
-    const travelersFinal = { adults: travelersIntermediate.adults, children: travelersIntermediate.children, childrenAges: travelersIntermediate.childrenAges, rooms: roomsToSend };
+    const travelersFinal = {
+      adults: travelersIntermediate.adults,
+      children: travelersIntermediate.children,
+      childrenAges: travelersIntermediate.childrenAges,
+      rooms: roomsToSend,
+    };
     onNext({ travelers: travelersFinal });
   };
 
@@ -30,11 +46,8 @@ export function StepRoomChoice({ onNext, travelersIntermediate, rooms }: StepCom
     if (value < roomsInfo.length) {
       setRoomsInfo(roomsInfo.slice(0, value));
     } else if (value > roomsInfo.length) {
-      setRoomsInfo([
-        ...roomsInfo,
-        { adults: 1, children: 0, childrenAges: [] }
-      ]);
-    }    
+      setRoomsInfo([...roomsInfo, { adults: 1, children: 0, childrenAges: [] }]);
+    }
   };
 
   const setRoomAdults = (value: number, index: number) => {
@@ -62,19 +75,25 @@ export function StepRoomChoice({ onNext, travelersIntermediate, rooms }: StepCom
   };
 
   const validateRoomsInfo = () => {
-    let totalAdults = 0, totalChildren = 0;
+    let totalAdults = 0,
+      totalChildren = 0;
     roomsInfo.forEach((r, i) => {
       totalAdults += r.adults;
       totalChildren += r.children;
     });
 
-    return totalAdults !== travelersIntermediate.adults || totalChildren !== travelersIntermediate.children;
-  }
+    return (
+      totalAdults !== travelersIntermediate.adults ||
+      totalChildren !== travelersIntermediate.children
+    );
+  };
 
   return (
     <Grid gap={24}>
       <div>
-        <Text heading size="xs" className="mt-md">Quantos quartos vocês vão precisar?</Text>
+        <Text heading size="xs" className="mt-md">
+          Quantos quartos vocês vão precisar?
+        </Text>
         <Text className="color-text-secondary mt-sm" size="md">
           Precisamos entender a organização de quartos para escolher a melhor hospedagem para vocês
         </Text>
@@ -90,12 +109,12 @@ export function StepRoomChoice({ onNext, travelersIntermediate, rooms }: StepCom
         step={1}
         disabled={submitting}
       />
-      <Grid columns={{"sm": 1, "md": [1, 3]}}>
+      <Grid columns={{ sm: 1, md: [1, 3] }}>
         {roomsInfo.map((room, index) => {
           return (
             <>
               <Text size="md">Quarto {index + 1}</Text>
-              <Grid columns={{"sm": 1, "md": 2}}>
+              <Grid columns={{ sm: 1, md: 2 }}>
                 <IncrementField
                   className="slider--with-steps"
                   name={`room-${index}-adults`}
@@ -123,15 +142,21 @@ export function StepRoomChoice({ onNext, travelersIntermediate, rooms }: StepCom
           );
         })}
       </Grid>
-      <SubmitButton
-        className="mt-md"
-        variant="tertiary"
-        disabled={submitting || validateRoomsInfo()}
-        submitting={submitting}
-        onClick={handleSubmit}
-      >
-        Receber minha recomendação
-      </SubmitButton>
+
+      <Grid gap={8} columns={[1, 3]} className="mt-md">
+        <Button onClick={onPrevious} iconName="chevron-left" variant="neutral">
+          Anterior
+        </Button>
+
+        <SubmitButton
+          variant="tertiary"
+          disabled={submitting || validateRoomsInfo()}
+          submitting={submitting}
+          onClick={handleSubmit}
+        >
+          Receber minha recomendação
+        </SubmitButton>
+      </Grid>
     </Grid>
   );
 }

--- a/src/features/trips/TripSteps/step-travelers-count.tsx
+++ b/src/features/trips/TripSteps/step-travelers-count.tsx
@@ -2,14 +2,20 @@ import { useState } from "react";
 
 import type { StepComponentProps } from "@/features";
 import { IncrementField, Text } from "@/ui";
-import { Grid, SubmitButton } from "mars-ds";
+import { Button, Grid, SubmitButton } from "mars-ds";
 
 import { formatToPlural } from "@/utils/helpers/number.helpers";
 
 const DEFAULT_ADULTS = 2;
 const BASE_CHILDREN_AGE = 6;
 
-export function StepTravelersCount({ onNext, numAdults = DEFAULT_ADULTS, numChildren, childrenAgeInfo }: StepComponentProps) {
+export function StepTravelersCount({
+  onNext,
+  onPrevious,
+  numAdults = DEFAULT_ADULTS,
+  numChildren,
+  childrenAgeInfo,
+}: StepComponentProps) {
   const [submitting, setSubmitting] = useState(false);
   const [adults, setAdults] = useState(numAdults);
   const [children, setChildrenInternal] = useState(numChildren ?? 0);
@@ -25,12 +31,7 @@ export function StepTravelersCount({ onNext, numAdults = DEFAULT_ADULTS, numChil
     if (value <= 0) {
       setChildrenAges([]);
     } else if (value > children) {
-      setChildrenAges(
-        [
-          ...childrenAges,
-          BASE_CHILDREN_AGE
-        ]
-      )
+      setChildrenAges([...childrenAges, BASE_CHILDREN_AGE]);
     } else {
       setChildrenAges(childrenAges.slice(0, value));
     }
@@ -81,13 +82,16 @@ export function StepTravelersCount({ onNext, numAdults = DEFAULT_ADULTS, numChil
       {children > 0 ? (
         <>
           <div>
-            <Text heading size="xs" className="mt-md">Qual a idade {(children === 1 ? "da criança" : "das crianças")}?</Text>
+            <Text heading size="xs" className="mt-md">
+              Qual a idade {children === 1 ? "da criança" : "das crianças"}?
+            </Text>
             <Text className="color-text-secondary mt-sm" size="md">
-              Para encontrar a melhor hospedagem para vocês, precisamos saber a idade das crianças no momento do checkout
+              Para encontrar a melhor hospedagem para vocês, precisamos saber a idade das crianças
+              no momento do checkout
             </Text>
           </div>
-          <Grid columns={{"sm": 1, "md": 2}}>
-            {childrenAges?.map((childrenAge, index) => 
+          <Grid columns={{ sm: 1, md: 2 }}>
+            {childrenAges?.map((childrenAge, index) => (
               <IncrementField
                 key={index}
                 className="slider--with-steps"
@@ -100,19 +104,27 @@ export function StepTravelersCount({ onNext, numAdults = DEFAULT_ADULTS, numChil
                 step={1}
                 disabled={submitting}
               />
-            )}
+            ))}
           </Grid>
-        </>) 
-        : <></>}
-      <SubmitButton
-        className="mt-md"
-        variant="tertiary"
-        disabled={submitting}
-        submitting={submitting}
-        onClick={handleSubmit}
-      >
-        Continuar
-      </SubmitButton>
+        </>
+      ) : (
+        <></>
+      )}
+
+      <Grid gap={8} columns={[1, 3]} className="mt-md">
+        <Button onClick={onPrevious} iconName="chevron-left" variant="neutral">
+          Anterior
+        </Button>
+
+        <SubmitButton
+          variant="tertiary"
+          disabled={submitting}
+          submitting={submitting}
+          onClick={handleSubmit}
+        >
+          Continuar
+        </SubmitButton>
+      </Grid>
     </Grid>
   );
 }

--- a/src/features/trips/TripSteps/step-trip-goal.tsx
+++ b/src/features/trips/TripSteps/step-trip-goal.tsx
@@ -2,7 +2,7 @@ import { QuestionsBuilder, type StepComponentProps } from "@/features";
 import { TripsApiService } from "@/services/api";
 import { AnswersDto } from "@/services/api/profile/answers";
 
-export function StepTripGoal({ onNext }: StepComponentProps) {
+export function StepTripGoal({ onNext, onPrevious }: StepComponentProps) {
   const handleSubmit = async (tripBehavior: AnswersDto) => {
     onNext({ tripBehavior });
   };
@@ -15,6 +15,8 @@ export function StepTripGoal({ onNext }: StepComponentProps) {
       finishButtonLabel="Continuar"
       disableLocalSave
       hideStepper
+      showPreviousButton={true}
+      onPrevious={onPrevious}
     />
   );
 }

--- a/src/features/trips/TripSteps/step-trip.tsx
+++ b/src/features/trips/TripSteps/step-trip.tsx
@@ -27,6 +27,7 @@ const TRIP_STEPS = [
         {...props}
         startDate={String(addMonths(new Date(), 3))}
         endDate={String(addMonths(new Date(), 3))}
+        showPrevious={true}
       />
     ),
   },


### PR DESCRIPTION
### Link da tarefa

[Task 420](https://github.com/tripevolved/front-next/issues/420)

### Contexto do PR

Foi solicitado um botão da voltar no fluxo de Descobrir sua trip e Já sei para onde ir

#### Lista do que foi feito:

- [x] Adicionado botão de Anterior a partir do step dois
- [x] Ajustado função do QuestionBuilder para usar o onPrevious

#### Sobre a solução

Adicionei os botões de "Anterior" nos steps que tinham botão "Continuar" e usei o onPrevious para do Step para voltar, também adicionei um boleano showPrevious, para não impactar outras telas que reaproveitam o componente. 

Já o QuestionBuilder tinha um função de onNavigation sendo usada, onde o onSubmit e o submitting foram implementados para funcionar nas steps da criação da trip, então eu adicionei o onPrevious para fazer o retorno e adicionei um booleano para exibir o botão sem impactar outros fluxos que usam o QuestionBuilder.

### Checklist

Esse PR:

- [x] foi testado localmente
- [ ] foi testado em ambiente de homologação
- [ ] possui testes unitários
- [ ] possui testes funcionais
- [ ] foi testado por alguém da equipe (não dev)

### Imagens, PrintScreens, vídeos

- Descobrir minha trip:

https://github.com/user-attachments/assets/4166bcb2-5a1a-4a01-9871-7439c5fe5b21

- Já sei para onde ir:

https://github.com/user-attachments/assets/6365c394-da06-4b33-b491-7a01aed0349d

