### PR TITLE
fix: adding spacing in accomodation details modal in checkout

### DIFF
--- a/src/features/stays/StayCheckoutModal/stay-checkout-modal.component.tsx
+++ b/src/features/stays/StayCheckoutModal/stay-checkout-modal.component.tsx
@@ -3,67 +3,88 @@ import type { StayCheckoutModalProps } from "./stay-checkout-modal.types";
 import { Card, CardElevations, Divider, Grid } from "mars-ds";
 import { toFullDate, toFullDetailedDate } from "@/utils/helpers/dates.helpers";
 
-export function StayCheckoutModal({
-  details
-}: StayCheckoutModalProps) {
+export function StayCheckoutModal({ details }: StayCheckoutModalProps) {
   return (
     <>
       <Text size="sm" heading className="trip-stay-checkout__header">
         Detalhes da hospedagem
       </Text>
-      {details.map((stay, i) => {
-        return (
-          <>
-            <Text size="xs" heading className="trip-stay-checkout__title">
-              {`Hospedagem ${i+1}`}
-            </Text>
-            <Card elevation={CardElevations.Low} className="trip-stay-checkout" key={i}>
-              <Grid columns={["25%", "auto"]}>
-                <Picture src={stay.coverImageUrl || "/assets/blank-image.png"} />
-                <div>
-                  <Text as="h3" size="lg">
-                    {stay.name}
-                  </Text>
-                  <Text style={{ marginTop: 0, color: "var(--color-brand-4)" }}>
-                    {stay.tags}
-                  </Text>
-                </div>
-              </Grid>
-              <TripStayCheckoutSection title={"Check-in"} text={toFullDetailedDate(stay.checkIn) ?? ""} />
-              <TripStayCheckoutSection title={"Check-out"} text={toFullDetailedDate(stay.checkOut) ?? ""} />
-              {stay.guests && <TripStayCheckoutSection title={"Hóspedes"} text={`${stay.guests}`} />}
-              {stay.boardInfo && (
-                <>
-                  <TripStayCheckoutSection title={"Quarto"} text={stay.boardInfo.roomName} />
-                  {stay.boardInfo.boardChoice && <TripStayCheckoutSection title={"Incluído"} text={stay.boardInfo.boardChoice} />}
-                </>
-              )}
-              {stay.rules && stay.rules.length > 0 && (
-                <>
-                  <Divider className="trip-stay-checkout__divider"/>
-                  <div className="trip-stay-checkout__section">
-                    <Text size="xl" className="trip-stay-checkout__section__title">
-                      <strong>Serviços da acomodação</strong>
-                    </Text>
-                    {stay.rules.map((rule, i) => {
-                      return (
-                        <Text size="md" className="trip-stay-checkout__section__text" key={i}>
-                          &#x2022; {rule}
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: "30px",
+        }}
+      >
+        {details.map((stay, i) => {
+          return (
+            <>
+              <div>
+                <Text size="xs" heading className="trip-stay-checkout__title">
+                  {`Hospedagem ${i + 1}`}
+                </Text>
+                <Card elevation={CardElevations.Low} className="trip-stay-checkout" key={i}>
+                  <Grid columns={["25%", "auto"]}>
+                    <Picture src={stay.coverImageUrl || "/assets/blank-image.png"} />
+                    <div>
+                      <Text as="h3" size="lg">
+                        {stay.name}
+                      </Text>
+                      <Text style={{ marginTop: 0, color: "var(--color-brand-4)" }}>
+                        {stay.tags}
+                      </Text>
+                    </div>
+                  </Grid>
+                  <TripStayCheckoutSection
+                    title={"Check-in"}
+                    text={toFullDetailedDate(stay.checkIn) ?? ""}
+                  />
+                  <TripStayCheckoutSection
+                    title={"Check-out"}
+                    text={toFullDetailedDate(stay.checkOut) ?? ""}
+                  />
+                  {stay.guests && (
+                    <TripStayCheckoutSection title={"Hóspedes"} text={`${stay.guests}`} />
+                  )}
+                  {stay.boardInfo && (
+                    <>
+                      <TripStayCheckoutSection title={"Quarto"} text={stay.boardInfo.roomName} />
+                      {stay.boardInfo.boardChoice && (
+                        <TripStayCheckoutSection
+                          title={"Incluído"}
+                          text={stay.boardInfo.boardChoice}
+                        />
+                      )}
+                    </>
+                  )}
+                  {stay.rules && stay.rules.length > 0 && (
+                    <>
+                      <Divider className="trip-stay-checkout__divider" />
+                      <div className="trip-stay-checkout__section">
+                        <Text size="xl" className="trip-stay-checkout__section__title">
+                          <strong>Serviços da acomodação</strong>
                         </Text>
-                      )
-                    })}
-                  </div>
-                </>
-              )}
-            </Card>
-          </>
-        );
-      })}
+                        {stay.rules.map((rule, i) => {
+                          return (
+                            <Text size="md" className="trip-stay-checkout__section__text" key={i}>
+                              &#x2022; {rule}
+                            </Text>
+                          );
+                        })}
+                      </div>
+                    </>
+                  )}
+                </Card>
+              </div>
+            </>
+          );
+        })}
+      </div>
     </>
   );
 }
 
-const TripStayCheckoutSection = ({ title, text } : { title: string, text: string }) => {
+const TripStayCheckoutSection = ({ title, text }: { title: string; text: string }) => {
   return (
     <div className="trip-stay-checkout__section">
       <Text size="xl" className="trip-stay-checkout__section__title">
@@ -74,4 +95,4 @@ const TripStayCheckoutSection = ({ title, text } : { title: string, text: string
       </Text>
     </div>
   );
-}
+};


### PR DESCRIPTION

### Link da tarefa

[Tarefa 430](https://github.com/tripevolved/front-next/issues/430)

### Contexto do PR

Foi requisitado que fosse adicionado um espaçamento na modal de detalhes de acomodação no checkout (em casos que haja mais de uma acomodação), para promover um ajuste no layout e deixar o mesmo mais bonito

#### Lista do que foi feito:

- [ ] Adição do espaçamento
- [ ] Ajuste do código HTML

#### Sobre a solução

Foi apenas utilizado classes CSS, utilizando os padrão flexbox, para promover esse ajuste no espaçamento

### Checklist

Esse PR:

- [X ] foi testado localmente
- [ ] foi testado em ambiente de homologação
- [ ] possui testes unitários
- [ ] possui testes funcionais
- [ ] foi testado por alguém da equipe (não dev)

### Imagens, PrintScreens, vídeos

Antes: 

![image](https://github.com/user-attachments/assets/3622f85c-5fbc-40ed-95ae-352223aef76d)


Depois:
![image](https://github.com/user-attachments/assets/12d8a8a5-c306-4991-9b77-cce8b67988fb)

