### PR TITLE
feat: adding autofilling checkbox to the first traveler

### DIFF
--- a/src/features/payments/PaymentSteps/step-travelers.tsx
+++ b/src/features/payments/PaymentSteps/step-travelers.tsx
@@ -1,10 +1,11 @@
 import type { Traveler } from "@/core/types";
-import type { PaymentStepProps } from "./payment-steps.types";
+import type { PaymentPayloadData, PaymentStepProps } from "./payment-steps.types";
 import { SelectFieldGender, Text } from "@/ui";
 
-import { Button, Divider, Grid, TextField, makeArray } from "mars-ds";
+import { Button, Checkbox, Divider, Grid, TextField, makeArray } from "mars-ds";
 import { type SubmitHandler, handleFormSubmit } from "@/utils/helpers/form.helpers";
 import { parseIsoToBRString } from "@/utils/helpers/dates.helpers";
+import React from "react";
 
 export const StepTravelers = ({ trip, onNext, setPayload, payload }: PaymentStepProps) => {
   const array = makeArray(trip.configuration.numAdults);
@@ -36,7 +37,12 @@ export const StepTravelers = ({ trip, onNext, setPayload, payload }: PaymentStep
           Precisamos dessas informações para garantir sua reserva!
         </Text>
         {array.map((_, index) => (
-          <TravelerForm key={`form-${index}`} index={index} data={payload.travelers?.[index]} />
+          <TravelerForm
+            key={`form-${index}`}
+            index={index}
+            data={payload.travelers?.[index]}
+            payerData={payload.payer}
+          />
         ))}
         <br />
         <Button variant="tertiary" type="submit">
@@ -50,32 +56,69 @@ export const StepTravelers = ({ trip, onNext, setPayload, payload }: PaymentStep
 interface TravelerFormProps {
   index: number;
   data?: Partial<Traveler>;
+  payerData: PaymentPayloadData["payer"];
 }
 
-const TravelerForm = ({ index = 0, data }: TravelerFormProps) => {
+const TravelerForm = ({ index = 0, data, payerData }: TravelerFormProps) => {
+  const [travelerData, setTravelerData] = React.useState<Partial<Traveler>>(data || {});
+  const [checked, setChecked] = React.useState(false);
   const position = index + 1;
+
+  const handleCheckbox = () => {
+    setChecked((prev) => !prev);
+    if (!checked) {
+      setTravelerData((prev) => ({
+        ...prev,
+        birthDate: payerData.birthDate,
+        fullName: payerData.fullName,
+        cpf: payerData.cpf,
+        rg: payerData.document,
+        gender: payerData.gender,
+        email: payerData.email,
+      }));
+    }
+  };
+
+  const removeIndexFromName = (name: string) => name.replace(/^\d+\./, "");
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+
+    const fieldName = removeIndexFromName(name) as keyof typeof payerData;
+
+    setTravelerData((prev) => ({ ...prev, [name]: value }));
+    if (payerData[fieldName] !== value) {
+      setChecked(false);
+    }
+  };
+
   return (
     <Grid>
       <Divider key={`divider-${index}`} />
       <Text>Viajante {position}:</Text>
-      {data?.id ? <input type="hidden" name={`${index}.id`} value={data.id} /> : null}
-      {data?.travelerId ? (
-        <input type="hidden" name={`${index}.travelerId`} value={data.travelerId} />
+      {travelerData?.id ? (
+        <input type="hidden" name={`${index}.id`} value={travelerData.id} />
+      ) : null}
+      {travelerData?.travelerId ? (
+        <input type="hidden" name={`${index}.travelerId`} value={travelerData.travelerId} />
       ) : null}
       <TextField
         required
         label="Nome completo"
-        value={data?.fullName}
+        value={travelerData?.fullName}
+        defaultValue={travelerData?.fullName}
         name={`${index}.fullName`}
         minLength={3}
+        onChange={handleChange}
       />
       <TextField
         required
         label="CPF"
-        value={data?.cpf}
+        value={travelerData?.cpf}
         mask={"999.999.999-99"}
         name={`${index}.cpf`}
         minLength={14}
+        onChange={handleChange}
       />
       <Grid columns={{ sm: 2 }}>
         <TextField
@@ -85,20 +128,34 @@ const TravelerForm = ({ index = 0, data }: TravelerFormProps) => {
           label="Data de Nascimento"
           type="text"
           mask="99/99/9999"
-          value={parseIsoToBRString(data?.birthDate)}
+          value={parseIsoToBRString(travelerData?.birthDate)}
           minLength={10}
+          onChange={handleChange}
         />
-        <SelectFieldGender name={`${index}.gender`} required defaultValue={data?.gender} />
+        <SelectFieldGender
+          name={`${index}.gender`}
+          required
+          key={`gender-${travelerData.gender || "not-informed"}`}
+          value={travelerData.gender}
+        />
       </Grid>
-      <TextField label="E-mail" name={`${index}.email`} type="email" value={data?.email} required />
+      <TextField
+        label="E-mail"
+        name={`${index}.email`}
+        type="email"
+        value={travelerData?.email}
+        required
+        onChange={handleChange}
+      />
       <TextField
         required
         label="Número do RG"
         name={`${index}.rg`}
         mask="9999999999"
-        value={data?.rg}
+        value={travelerData?.rg}
         maxLength={10}
         minLength={3}
+        onChange={handleChange}
       />
       <Grid columns={{ sm: 2 }}>
         <TextField
@@ -108,17 +165,23 @@ const TravelerForm = ({ index = 0, data }: TravelerFormProps) => {
           label="Validade do RG"
           type="text"
           mask="99/99/9999"
-          value={parseIsoToBRString(data?.rgValidUntil)}
+          value={parseIsoToBRString(travelerData?.rgValidUntil)}
           minLength={10}
         />
         <TextField
           required
           label="Emissor do RG"
-          value={data?.rgIssuer}
+          value={travelerData?.rgIssuer}
           name={`${index}.rgIssuer`}
           minLength={3}
           maxLength={10}
         />
+        {position === 1 && (
+          <div style={{ display: "flex", flexDirection: "row", alignItems: "center" }}>
+            <Text>Eu mesmo sou o viajante:</Text>
+            <Checkbox onClick={handleCheckbox} defaultChecked={checked} />
+          </div>
+        )}
       </Grid>
     </Grid>
   );


### PR DESCRIPTION

[Tarefa 429](https://github.com/tripevolved/front-next/issues/429)

### Contexto do PR

Foi requisitado que fosse adicionado um checkbox no processo de Checkout, de forma que os dados do Viajante 1, pudessem ser autocompletados com os dados do pagante, assim, facilitando o processo e experiência do pagamento da viagem

#### Lista do que foi feito:

- [ ] Adição do checkbox
- [ ] Adição da lógica de autofilling
- [ ] Correção de bugs

#### Sobre a solução

Foi apenas adicionado um checkbox somente para o viajante 1, o qual sempre completará os dados do formulário com os dados do pagante, caso seja clicado.

### Checklist

Esse PR:

- [X] foi testado localmente
- [ ] foi testado em ambiente de homologação
- [ ] possui testes unitários
- [ ] possui testes funcionais
- [ ] foi testado por alguém da equipe (não dev)

### Imagens, PrintScreens, vídeos

![VAMOOO](https://github.com/user-attachments/assets/3b839e84-f8e5-4370-b6de-6fefe4a9a297)

