### PR TITLE
fix: adjusting header option to talk with specialist

### DIFF
--- a/src/features/templates/PageAppHeader/page-app-header.component.tsx
+++ b/src/features/templates/PageAppHeader/page-app-header.component.tsx
@@ -4,6 +4,7 @@ import { Avatar, Button, Container, Divider, Grid, Modal, ToggleButton } from "m
 import { makeCn } from "@/utils/helpers/css.helpers";
 import { NotificationButton } from "@/features";
 import { useRouter } from "next/router";
+import { getWhatsappLink } from "@/utils/helpers/whatsapp.helpers";
 
 export interface PageAppHeaderProps {
   image?: string;
@@ -97,8 +98,12 @@ const MENU = [
         href: "/app/viagens/descobrir",
       },
       {
-        label: "Contratar suporte",
-        disabled: true,
+        label: "Falar com especialista",
+        disabled: false,
+        iconName: "whatsapp",
+        onClick: () => {
+          window.open(getWhatsappLink("Olá, eu gostaria de planejar a minha próxima viagem!"));
+        },
       },
       {
         label: "Sair da conta",


### PR DESCRIPTION


### Link da tarefa

[Tarefa 466](https://github.com/tripevolved/front-next/issues/466)

### Contexto do PR

Foi requisitado que fosse alterado o texto do header para contatar o suporte por whatsapp, também como corrigir a funcionalidade de iniciar a conversa por whatsapp

#### Lista do que foi feito:

- [ ] Ajustado texto da opção do header
- [ ] Adicionado ícone de whatsapp na opção do header
- [ ] Ajustado função para enviar para o Whatsapp


### Checklist

Esse PR:

- [X] foi testado localmente
- [ ] foi testado em ambiente de homologação
- [ ] possui testes unitários
- [ ] possui testes funcionais
- [ ] foi testado por alguém da equipe (não dev)

### Imagens, PrintScreens, vídeos

![GIF whatsapp](https://github.com/user-attachments/assets/dd8ab617-a659-4c3e-aefd-3d1df4b24a18)
