### PR TITLE
feat: adding image select component

### DIFF
--- a/src/ui/components/forms/ImageSelect/image-select.component.tsx
+++ b/src/ui/components/forms/ImageSelect/image-select.component.tsx
@@ -1,0 +1,57 @@
+import Image from "next/image";
+import { ImageSelectProps } from "./image-select.types";
+
+export function ImageSelect({ onClick, selected, disabled, name, imageUrl }: ImageSelectProps) {
+  return (
+    <>
+      <div
+        className="image__select__component__container"
+        style={{
+          cursor: disabled && !selected ? "default" : "pointer",
+        }}
+        onClick={onClick}
+      >
+        <div style={{ position: "relative" }}>
+          <Image
+            key={name}
+            className="image__select__component__destination__image"
+            alt="Destination"
+            src={imageUrl}
+            width={105}
+            height={105}
+            style={{
+              border: selected ? "3px solid #0ab9ad" : "none",
+              filter: disabled && !selected ? "grayscale(100%)" : "none",
+            }}
+          />
+          <div
+            className="option-field option-field--is-multiselect top-1 right-1 border-white image__select__checkbox__container"
+            style={{
+              cursor: disabled && !selected ? "default" : "pointer",
+            }}
+          >
+            <input
+              type="checkbox"
+              className="image__select__checkbox"
+              style={{
+                cursor: disabled && !selected ? "default" : "pointer",
+              }}
+              defaultChecked={selected}
+              disabled={disabled}
+              onClick={onClick}
+            />
+            <span
+              className="option-field__state"
+              style={{
+                borderColor: selected ? "#0ab9ad" : "white",
+                cursor: disabled && !selected ? "default" : "pointer",
+              }}
+              data-checked={selected}
+            />
+          </div>
+        </div>
+        <span>{name}</span>
+      </div>
+    </>
+  );
+}

--- a/src/ui/components/forms/ImageSelect/image-select.styles.scss
+++ b/src/ui/components/forms/ImageSelect/image-select.styles.scss
@@ -1,0 +1,23 @@
+.image__select__component__container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+}
+
+.image__select__component__destination__image {
+  object-fit: cover;
+  border-radius: 15px;
+}
+
+.image__select__checkbox__container {
+  position: absolute !important;
+  top: 5px;
+  right: 5px;
+}
+
+.image__select__checkbox {
+  width: 16px;
+  height: 16px;
+  background: none;
+}

--- a/src/ui/components/forms/ImageSelect/image-select.types.ts
+++ b/src/ui/components/forms/ImageSelect/image-select.types.ts
@@ -1,0 +1,7 @@
+export type ImageSelectProps = {
+  name: string;
+  imageUrl: string;
+  selected?: boolean;
+  disabled?: boolean;
+  onClick?: (event: React.MouseEvent<HTMLDivElement>) => void;
+};

--- a/src/ui/components/forms/ImageSelect/index.ts
+++ b/src/ui/components/forms/ImageSelect/index.ts
@@ -1,0 +1,2 @@
+export * from "./image-select.component";
+export * from "./image-select.types";

--- a/src/ui/components/index.scss
+++ b/src/ui/components/index.scss
@@ -33,6 +33,7 @@
 @import "./forms/DatePicker/date-picker.styles.scss";
 @import "./forms/IncrementField/increment-field.styles.scss";
 @import "./forms/MultiSelectField/multi-select-field.styles.scss";
+@import "./forms/ImageSelect/image-select.styles.scss";
 @import "./forms/OptionField/option-field.styles.scss";
 @import "./forms/OptionsSelectField/options-select-field.styles.scss";
 @import "./forms/SelectFieldSimple/select-field-simple.styles.scss";


### PR DESCRIPTION
### Link da tarefa

[Tarefa 456](https://github.com/tripevolved/front-next/issues/456)

### Contexto do PR

Foi requisitado que fosse criado um componente de seleção de imagens, para que fosse inserido no processo de criação da Trip do Usuário;

#### Lista do que foi feito:

- [ ] Criação da base do componente
- [ ] Ajustes da lógica do checkbox
- [ ] Ajustes na estilização
- [ ] Ajustes na lógica de disabled

### Checklist

Esse PR:

- [X] foi testado localmente
- [ ] foi testado em ambiente de homologação
- [ ] possui testes unitários
- [ ] possui testes funcionais
- [ ] foi testado por alguém da equipe (não dev)

### Imagens, PrintScreens, vídeos

![Gif Imagens](https://github.com/user-attachments/assets/da3ef4e3-1f16-4159-aca4-92b768a2a713)



