### PR TITLE
feat: Adding simple image selection component

### DIFF
--- a/src/ui/components/forms/RadioCard/index.ts
+++ b/src/ui/components/forms/RadioCard/index.ts
@@ -1,0 +1,2 @@
+export * from "./radio-card.component";
+export * from "./radio-card.types";

--- a/src/ui/components/forms/RadioCard/radio-card.component.tsx
+++ b/src/ui/components/forms/RadioCard/radio-card.component.tsx
@@ -1,0 +1,29 @@
+import Image from "next/image";
+import { RadioCardProps } from "./radio-card.types";
+
+export function RadioCard({ image, description, onClick }: RadioCardProps) {
+  return (
+    <>
+      <div
+        className="flex flex-row items-center border border-[#E0E0E0] gap-4 rounded-xl"
+        style={{
+          padding: "20px",
+          maxWidth: 360,
+        }}
+      >
+        <div className="flex flex-row items-start relative gap-3">
+          <input type="radio" className="w-5 h-5" onClick={onClick} />
+          <Image
+            width={120}
+            height={100}
+            src={image}
+            alt="Simple Selection"
+            className="rounded-xl object-cover"
+          />
+        </div>
+
+        <p className="text-left flex-1 flex-wrap">{description}</p>
+      </div>
+    </>
+  );
+}

--- a/src/ui/components/forms/RadioCard/radio-card.types.ts
+++ b/src/ui/components/forms/RadioCard/radio-card.types.ts
@@ -1,0 +1,5 @@
+export type RadioCardProps = {
+  image: string;
+  description: string;
+  onClick: () => void;
+};


### PR DESCRIPTION


### Link da tarefa

[Tarefa 457](https://github.com/tripevolved/front-next/issues/457)
### Contexto do PR

Foi requisitado que fosse criado um componente de seleção simples com uma imagem ao lado. Para assim possuirmos mais opções customizadas durante o processo de criação da trip do usuário.

#### Lista do que foi feito:

- [ ] Criação do componente
- [ ] Adição das tipagens
- [ ] Adição dos estilos



### Checklist

Esse PR:

- [X] foi testado localmente
- [ ] foi testado em ambiente de homologação
- [ ] possui testes unitários
- [ ] possui testes funcionais
- [ ] foi testado por alguém da equipe (não dev)

### Imagens, PrintScreens, vídeos

![image](https://github.com/user-attachments/assets/9be7aa4c-5533-474d-af92-4fb2ba106f99)


### Referências: artigos, documentação

Referência do Figma:

![image](https://github.com/user-attachments/assets/d6717abb-d418-4a07-9c91-9c7cf0634fdd)
