### PR TITLE
fix: Readding modal to destiny recomendation pages

### DIFF
--- a/src/components/TripPlanningDecisionModal.tsx
+++ b/src/components/TripPlanningDecisionModal.tsx
@@ -14,6 +14,8 @@ interface TripPlanningDecisionModalProps {
   onClose: () => void;
   selectedDestination: string | null;
   onContactExpert: () => void;
+  onWantToGo: (destinationId: string) => Promise<void>;
+  isPublic: boolean;
 }
 
 export default function TripPlanningDecisionModal({
@@ -21,6 +23,8 @@ export default function TripPlanningDecisionModal({
   onClose,
   selectedDestination,
   onContactExpert,
+  onWantToGo,
+  isPublic,
 }: TripPlanningDecisionModalProps) {
   const [destination, setDestination] = useState<PublicDestination | null>(null);
   const [isLoading, setIsLoading] = useState(true);
@@ -117,19 +121,32 @@ export default function TripPlanningDecisionModal({
         <div className="sticky bottom-0 bg-white border-t border-gray-200 p-6 z-10">
           <div className="flex flex-col md:flex-row gap-4">
             <div className="relative group flex-1">
-              <button
-                className="w-full bg-primary-600 text-white py-2 rounded-full font-medium opacity-70 cursor-not-allowed flex items-center justify-center border border-primary-700 shadow-sm"
-                disabled
-              >
-                <span>Planejar minha viagem</span>
-                <span className="ml-2 bg-accent-500 text-white text-xs px-2 py-0.5 rounded">
-                  Em breve
-                </span>
-              </button>
-              <div className="absolute -top-20 left-1/2 transform -translate-x-1/2 bg-white text-gray-800 text-xs px-4 py-3 rounded shadow-lg opacity-0 group-hover:opacity-100 transition-opacity duration-200 w-80 text-center border border-gray-200">
-                Em breve você poderá planejar sua viagem completa através da nossa plataforma,
-                contando com a curadoria de nossos especialistas
-              </div>
+              {!isPublic ? (
+                <div className="relative group flex-1">
+                  <button
+                    className="w-full bg-primary-600 text-white py-2 rounded-full font-medium opacity-70 flex items-center justify-center border border-primary-700 shadow-sm hover:bg-primary-700 transition-colors"
+                    onClick={() => onWantToGo(destination?.id as string)}
+                  >
+                    <span>Planejar minha viagem</span>
+                  </button>
+                </div>
+              ) : (
+                <div className="relative group flex-1">
+                  <button
+                    className="w-full bg-primary-600 text-white py-2 rounded-full font-medium opacity-70 cursor-not-allowed flex items-center justify-center border border-primary-700 shadow-sm"
+                    disabled
+                  >
+                    <span>Planejar minha viagem</span>
+                    <span className="ml-2 bg-accent-500 text-white text-xs px-2 py-0.5 rounded">
+                      Em breve
+                    </span>
+                  </button>
+                  <div className="absolute -top-20 left-1/2 transform -translate-x-1/2 bg-white text-gray-800 text-xs px-4 py-3 rounded shadow-lg opacity-0 group-hover:opacity-100 transition-opacity duration-200 w-80 text-center border border-gray-200">
+                    Em breve você poderá planejar sua viagem completa através da nossa plataforma,
+                    contando com a curadoria de nossos especialistas
+                  </div>
+                </div>
+              )}
             </div>
 
             {hasTraveler ? (

--- a/src/components/results/ResultsDestinationCard.tsx
+++ b/src/components/results/ResultsDestinationCard.tsx
@@ -5,7 +5,6 @@ import setSeconds from "date-fns/esm/setSeconds/index.js";
 
 export interface ResultsDestinationCardProps {
   destination: TripMatchedDestination;
-  onWantToGo: (id: string) => void;
   isLarge?: boolean;
   isMainChoice?: boolean;
   onPlanningTripToGo: Dispatch<SetStateAction<boolean>>;
@@ -24,7 +23,6 @@ const profileIcons: Record<string, string> = {
 
 export function ResultsDestinationCard({
   destination,
-  onWantToGo,
   isMainChoice = false,
   isLarge = false,
   onPlanningTripToGo,
@@ -68,7 +66,6 @@ export function ResultsDestinationCard({
 
   const onClick = (destination: TripMatchedDestination) => {
     onPlanningTripToGo(true);
-    onWantToGo(destination.destinationId);
     setSelectedDestination.current = destination.uniqueName;
   };
 

--- a/src/components/results/ResultsTrip.tsx
+++ b/src/components/results/ResultsTrip.tsx
@@ -65,7 +65,6 @@ export function ResultsTrip({
               <ResultsDestinationCard
                 destination={tripProposal.mainChoice}
                 isLarge={true}
-                onWantToGo={setDestinationById}
                 isMainChoice={true}
                 onPlanningTripToGo={setIsWantToGoModalOpen}
                 setSelectedDestination={selectedDestination}
@@ -86,7 +85,6 @@ export function ResultsTrip({
                     <ResultsDestinationCard
                       key={destination.destinationId}
                       destination={destination}
-                      onWantToGo={setDestinationById}
                       onPlanningTripToGo={setIsWantToGoModalOpen}
                       setSelectedDestination={selectedDestination}
                     />
@@ -101,7 +99,6 @@ export function ResultsTrip({
                     <ResultsDestinationCard
                       key={destination.destinationId}
                       destination={destination}
-                      onWantToGo={setDestinationById}
                       onPlanningTripToGo={setIsWantToGoModalOpen}
                       setSelectedDestination={selectedDestination}
                     />
@@ -167,6 +164,8 @@ export function ResultsTrip({
         }}
         selectedDestination={selectedDestination.current}
         onContactExpert={handleContactExpert}
+        onWantToGo={setDestinationById}
+        isPublic={isPublic}
       />
 
       {/* Contact Expert Modal */}


### PR DESCRIPTION
<!--
Items marcados com (*) são obrigatórios
-->

### Link da tarefa

[Tarefa 401](https://github.com/tripevolved/front-next/issues/501)

### Contexto do PR

Foi requisitado para que na tela de resultados da recomendação de destinos da modal, fosse readicionado a modal de recomendação de destinos, que havia sido perdida para ambos os casos (parte pública e parte logada

#### Lista do que foi feito:

- [ ] Ajustado lógica na parte pública
- [ ] Adicionado modal na parte pública
- [ ] Adicionado modal na parte privada
- [ ] Ajustado botões de CTA na parte logada

### Checklist

Esse PR:

- [X] foi testado localmente
- [ ] foi testado em ambiente de homologação
- [ ] possui testes unitários
- [ ] possui testes funcionais
- [ ] foi testado por alguém da equipe (não dev)

### Imagens, PrintScreens, vídeos

Parte pública:
![GIF Parte pública](https://github.com/user-attachments/assets/22110e85-9f6d-4fd6-9b51-cafa5c1224c8)

Parte privada: 

![image](https://github.com/user-attachments/assets/9bc6dd44-e6c9-465c-9280-30bc432e06ba)

